### PR TITLE
Fix to TPM calculation in presence of Ensembl transcript version fix

### DIFF
--- a/scripts/irap_raw2metric
+++ b/scripts/irap_raw2metric
@@ -186,7 +186,9 @@ lengths <- list(gene=gene.length,transcript=trans.length,exon=exon.length)
 if ( opt$feature=="transcript" && sum(grepl(".",rownames(table),fixed=TRUE))==nrow(table) && sum(grepl(".",names(trans.length),fixed=TRUE))==0 ) {
     pinfo("Applying Ensembl workaround...")
     rownames(table) <- gsub("\\.[0-9]+","",rownames(table))
-    mass.labels <- gsub("\\.[0-9]+","",mass.labels)
+    if (!is.null(mass.labels)) {
+        mass.labels <- gsub("\\.[0-9]+","",mass.labels)
+    }
     print(head(table))
 }
 ## Missing features in the GTF


### PR DESCRIPTION
This fix addresses an issue that was introduced by a previous fix, to deal with versions (.1 etc) appended to transcript identifiers.

The mass.labels variable (not entirely sure what this does, but it doesn't matter here) starts off and is set by various processes prior to the fixed line, but often remains NULL. However the Ensembl version fix unconditionally resets that, converting NULL to c() - an empty vector. This is not recognised as empty by e.g. countstable2tpm(), and incorrect NaNs result. 

The fix is simply to only adjust mass.labels when it was set in the first place.  